### PR TITLE
Add `splice` filter to templating docs.

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -1754,6 +1754,25 @@ Slice an iterator and return a list of lists containing those items:
     </ul>
 </div>
 ```
+
+### split
+
+Split a string by a given separator and return a list of resulting strings:
+
+**Input**
+
+```jinja
+{% set str = "/foo/bar/baz/" %}
+
+{% str.split('/') %}
+```
+
+**Output**
+
+```jinja
+,foo,bar,baz,
+```
+
 ### sort(arr, reverse, caseSens, attr)
 
 Sort `arr` with JavaScript's `arr.sort` function. If `reverse` is true, result


### PR DESCRIPTION
## Add `splice` filter to templating docs, which was not documented previously, although it is full supported.

Proposed change:

Adds new `splice` entry to `docs/templating.md` file, right after `slice` method description.

Closes #1173.

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [X] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [X] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [ ] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [ ] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->